### PR TITLE
Update to GNOME 45

### DIFF
--- a/QuickLaunch@github.com/extension.js
+++ b/QuickLaunch@github.com/extension.js
@@ -25,11 +25,8 @@ const IndicatorName = 'QuickLaunch';
 /**
  * Gicon Menu Item Object
  */
+let PopupGiconMenuItem = GObject.registerClass(
 class PopupGiconMenuItem extends PopupMenu.PopupBaseMenuItem {
-    static {
-        GObject.registerClass(this);
-    }
-
     _init(text, gIcon, params) {
         super._init(params);
 
@@ -40,15 +37,13 @@ class PopupGiconMenuItem extends PopupMenu.PopupBaseMenuItem {
         this.add_actor(this._icon);
         this.add_actor(this.label);
     }
-};
+});
 
 /**
  * QuickLaunch Object
  */
+let QuickLaunch = GObject.registerClass(
 class QuickLaunch extends PanelMenu.Button {
-    static {
-        GObject.registerClass(this);
-    }
 
     _init() {
         super._init( 0.0, IndicatorName );
@@ -192,7 +187,7 @@ class QuickLaunch extends PanelMenu.Button {
         return menuItem;
     }
 
-};
+});
 
 /**
  * Extension Setup

--- a/QuickLaunch@github.com/metadata.json
+++ b/QuickLaunch@github.com/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["41", "42"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch","version":10}
+{"shell-version": ["43", "41", "42"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch","version":10}

--- a/QuickLaunch@github.com/metadata.json
+++ b/QuickLaunch@github.com/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["43", "41", "42"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch","version":10}
+{"shell-version": ["45"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch","version":10}

--- a/QuickLaunch@github.com/metadata.json
+++ b/QuickLaunch@github.com/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.4", "3.6", "3.8", "3.10","3.11.5","3.12", "3.14", "3.16", "3.18"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch"}
+{"shell-version": ["41", "42"], "uuid": "QuickLaunch@github.com", "name": "QuickLaunch", "description": "Quick Launch - Launch custom made .desktop files from a directory", "url": "https://github.com/manno/gnome-shell-extension-quicklaunch","version":10}


### PR DESCRIPTION
Working with GNOME  45 after API changes.

I had to bin the set-up-new logic, as the tool it relies upon has been removed (gnome-desktop-item-edit).